### PR TITLE
Don't be verbose in build's file operations

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,8 @@ if [ ! -f "$BZIP_FILE" ]; then
     curl -OL https://bitbucket.org/pypy/pypy/downloads/${BZIP_FILE}
 fi
 cd ${PYPY_VERSION}
-tar -xvjf ../${BZIP_FILE}
+echo Extracting files from pypy download. Be patient.
+tar -xjf ../${BZIP_FILE}
 mv ${PKG_NAME} pypy
-zip -r ../../${PYPY_VERSION}.zip .
+echo Compressing Lambda layer files. Be patient.
+zip -r -q ../../${PYPY_VERSION}.zip .


### PR DESCRIPTION
Make tar and zip be quiet. Without this change, hundreds of filenames are printed to the console (twice) every time `make build` is run. It's no big deal, but I found this tweak useful, and thought you might too.